### PR TITLE
feat: style Docs Show Page

### DIFF
--- a/app/views/docs/show.html.haml
+++ b/app/views/docs/show.html.haml
@@ -1,7 +1,9 @@
-%h1= @doc.title
-%p= @doc.content
+.wrapper_with_padding
+  #doc_show
+    %h1= @doc.title
+    %p= simple_format(@doc.content)
 
-= link_to "All Docs", docs_path
-= link_to "Fix Doc", edit_doc_path(@doc)
-= link_to "Trash It", doc_path(@doc), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } 
+    .buttons
+    = link_to "Fix Doc", edit_doc_path(@doc), class: "button"
+    = link_to "Trash It", doc_path(@doc), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "button" 
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,13 +10,13 @@
     .header_inner
       = link_to "FileCabinet", root_path, id: "logo"
 
-      %nav
-        - if user_signed_in?
-          = link_to "Create Doc", new_doc_path
-          = link_to "Sign Out", destroy_user_session_path, data: { turbo_method: :delete }
+  %nav
+    - if user_signed_in?
+      = link_to "Create Doc", new_doc_path
+      = link_to "Sign Out", destroy_user_session_path, data: { turbo_method: :delete }
 
-        - else
-          = link_to "Log In", new_user_session_path
+    - else
+      = link_to "Log In", new_user_session_path
 
 
     %p.notice= notice


### PR DESCRIPTION
section9 31
CSS 一部エラー解消
原因　Headerの範囲が広く取られていた、これもインデントによるもの